### PR TITLE
Allow to turn off substitution of current locale subdomain in url_for

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,6 +73,26 @@ class AdminController
 end
 ```
 
+### `url_for` subdomain rewritting
+
+By default, `url_for` will generate links with subdomain of currently active
+locale which may differ from subdomain of current request if current subdomain
+is not included in locale mapping, or `url_for` is called inside
+`I18n.with_locale`. To disable this functionality, set:
+
+``` ruby
+config.current_locale_subdomain_in_url_for = false
+```
+
+This may be useful if your application has subdomains not mapped to locale. For
+example, if your admin panel has separate domain `admin.example.com` and you set
+English as single language in admin panel, `url_for` called inside admin
+controller or view will return links with `en.example.com` or `example.com`
+instead of `admin.example.com`. Using `redirect_to` with parameters hash or
+record will result in change of subdomain too. Set
+`current_locale_subdomain_in_url_for` to `false` to restore regular Rails
+behavior: using domain of current request in `url_for`.
+
 ## Testing
 
 This gem is tested against Rails 3.2, 4.0 and 4.1.
@@ -121,4 +141,3 @@ rake test:all
 * Clearly specifying I18n dependency.
 
 0.0.1—0.0.3. Initial releases.
-

--- a/lib/subdomain_locale/default_url_options.rb
+++ b/lib/subdomain_locale/default_url_options.rb
@@ -1,0 +1,13 @@
+module SubdomainLocale
+  module DefaultUrlOptions
+    def default_url_options
+      super.merge({
+        subdomain: subdomain_locales.subdomain_for(current_locale)
+      })
+    end
+
+    def current_locale
+      I18n.locale
+    end
+  end
+end

--- a/lib/subdomain_locale/railtie.rb
+++ b/lib/subdomain_locale/railtie.rb
@@ -5,6 +5,7 @@ module SubdomainLocale
     config.subdomain_locale = {}
     config.default_subdomain = "" # or "www"
     config.default_locale = nil
+    config.current_locale_subdomain_in_url_for = true
 
     # Execute after all application initializers, I18n is often configured there.
     config.after_initialize do |app|
@@ -19,6 +20,10 @@ module SubdomainLocale
     initializer "subdomain_locale.url_helpers" do
       require "subdomain_locale/url_for"
       Rails.application.routes.extend SubdomainLocale::UrlFor
+      if Rails.application.config.current_locale_subdomain_in_url_for
+        require "subdomain_locale/default_url_options"
+        Rails.application.routes.extend SubdomainLocale::DefaultUrlOptions
+      end
     end
 
     initializer "subdomain_locale.controller" do

--- a/lib/subdomain_locale/url_for.rb
+++ b/lib/subdomain_locale/url_for.rb
@@ -19,17 +19,7 @@ module SubdomainLocale
       super(options, *other)
     end
 
-    def default_url_options
-      super.merge({
-        subdomain: subdomain_locales.subdomain_for(current_locale)
-      })
-    end
-
     private
-
-    def current_locale
-      I18n.locale
-    end
 
     def subdomain_locales
       SubdomainLocale.mapping

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -45,6 +45,10 @@ class HelloControllerTest < ActionController::TestCase
     get :world
     assert_select "p", "Привет"
   end
+
+  def test_url_for_subdomain_replacement_by_default
+    assert Rails.application.config.current_locale_subdomain_in_url_for
+  end
 end
 
 class HelloMailerTest < ActionController::TestCase


### PR DESCRIPTION
Currently this gem assumes that your application uses subdomains only for locales. If app has other subdomains, for example for admin panel, it causes following problem: `url_for` called inside controllers or views in such domains will result in `admin.example.com` changed to `(language).example.com`. Calling ``redirect_to @thing`` will redirect from admin to language domain too (polymorphic routes' code calls `url_for`).

Although substituting subdomain for current locale in `url_for` is useful, sometimes it confuses and makes some things impossible.

This changeset adds `current_locale_subdomain_in_url_for` configuration parameter that, if set to `false`, disables patching of `default_url_options` and restores default Rails behavior for `url_for`: using current request's host and subdomain.

This parameter is `true` by default (retaining old gem behavior by default).