### PR TITLE
Fix set_locale name collision in around_action filter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,9 @@ rake test:all
 
 ## Changelog
 
+master
+
+* Support Rails 5.2 (fixed name collision of `set_locale` around action breaking Rails mailer previews).
 
 1.3.0
 

--- a/lib/subdomain_locale/controller.rb
+++ b/lib/subdomain_locale/controller.rb
@@ -1,15 +1,15 @@
 module SubdomainLocale
   module Controller
-    def self.included(base)
-      base.around_action :set_locale
+    class SetLocaleFilter
+      def self.around(controller)
+        locale = SubdomainLocale.mapping.locale_for(controller.request.subdomain)
+        locale = SubdomainLocale.default_fallback(locale)
+        I18n.with_locale(locale) { yield }
+      end
     end
 
-    private
-
-    def set_locale
-      locale = SubdomainLocale.mapping.locale_for(request.subdomain)
-      locale = SubdomainLocale.default_fallback(locale)
-      I18n.with_locale(locale) { yield }
+    def self.included(base)
+      base.around_action SetLocaleFilter
     end
   end
 end


### PR DESCRIPTION
`subdomain_locale` started to break Rails mailer previews after [locale selector](https://github.com/rails/rails/pull/31596) had been added to it. `subdomain_locale` sets up around action with method `set_locale`:

https://github.com/semaperepelitsa/subdomain_locale/blob/6aaf623fe1ce65cf04995aa7203edf2efdb2d5af/lib/subdomain_locale/controller.rb#L3-L5

And now `Rails::MailersController` [also has a method named `set_locale`](https://github.com/rails/rails/blob/ef1dbd8cc725f3df9080870ce58afd7d822df98a/railties/lib/rails/mailers_controller.rb#L95-L99). This, for some reason, causes any requests to `Rails::MailersController` to render empty page.

Moved filter to filter class.

`rake test:all` passes.